### PR TITLE
feat: Separate Next.js and Cloudflare Workers architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,136 @@
 # Sitemap Generator
+
+Web サイトの URL を入力してサイトマップ XML を自動生成する Web アプリケーション
+
+## アーキテクチャ
+
+- **Next.js 15**: フロントエンド（UI/Pages）
+- **Cloudflare Workers**: API 処理とクローリング
+- **TypeScript**: 型安全性の確保
+- **Tailwind CSS**: スタイリング
+
+## 開発環境のセットアップ
+
+### 1. 依存関係のインストール
+
+```bash
+# メインプロジェクトの依存関係
+pnpm install
+
+# Workers の依存関係
+cd workers && pnpm install
+```
+
+### 2. 環境変数の設定
+
+`.env.local` ファイルを作成し、以下の内容を設定：
+
+```bash
+# Workers API の URL（開発環境）
+NEXT_PUBLIC_WORKERS_API_URL=http://localhost:8787
+
+# 本番環境用
+CLOUDFLARE_WORKERS_DOMAIN=your-domain.workers.dev
+```
+
+### 3. 開発サーバーの起動
+
+#### 全体を同時に起動（推奨）
+
+```bash
+pnpm dev:full
+```
+
+#### 個別に起動
+
+```bash
+# Next.js（フロントエンド）
+pnpm dev
+
+# Cloudflare Workers（API）
+pnpm workers:dev
+```
+
+## デプロイ
+
+### 1. Workers のデプロイ
+
+```bash
+# Workers のみデプロイ
+pnpm workers:deploy
+
+# または、wrangler コマンドで直接
+cd workers && pnpm deploy
+```
+
+### 2. Next.js のデプロイ（Cloudflare Pages）
+
+```bash
+# Cloudflare Pages へのデプロイ
+pnpm cf:deploy
+
+# プレビュー
+pnpm cf:preview
+```
+
+### 3. 全体のデプロイ
+
+```bash
+# Workers と Next.js の両方をデプロイ
+pnpm deploy
+```
+
+## API 構成
+
+### Cloudflare Workers Endpoints
+
+- `GET /health` - ヘルスチェック
+- `POST /api/crawl` - サイトクローリング
+- `POST /api/sitemap/generate` - サイトマップ生成
+
+### Next.js API Routes
+
+Next.js の API Routes は使用せず、すべて Cloudflare Workers にプロキシされます。
+
+## テスト
+
+```bash
+# E2E テスト
+pnpm test:e2e
+
+# テスト UI
+pnpm test:e2e:ui
+
+# テストレポート
+pnpm test:e2e:report
+```
+
+## プロジェクト構成
+
+```
+sitemap-generator/
+├── app/                    # Next.js アプリケーション
+│   ├── components/         # React コンポーネント
+│   ├── lib/               # ユーティリティ・API クライアント
+│   └── page.tsx           # ページコンポーネント
+├── workers/               # Cloudflare Workers
+│   ├── src/
+│   │   ├── index.ts       # Workers エントリーポイント
+│   │   ├── crawler.ts     # クローリング処理
+│   │   └── sitemap-generator.ts  # サイトマップ生成
+│   └── wrangler.toml      # Workers 設定
+├── package.json           # メインプロジェクト設定
+└── README.md
+```
+
+## 開発のワークフロー
+
+1. **フロントエンド開発**: `app/` 配下で Next.js コンポーネントを開発
+2. **API 開発**: `workers/src/` 配下で Cloudflare Workers API を開発
+3. **統合テスト**: `pnpm dev:full` で全体を起動してテスト
+
+## 注意事項
+
+- API Routes は Next.js ではなく Cloudflare Workers で処理されます
+- 開発時は `http://localhost:8787` で Workers API にアクセス
+- 本番環境では `https://your-workers-domain.workers.dev` にアクセス

--- a/app/lib/workers-api.ts
+++ b/app/lib/workers-api.ts
@@ -1,0 +1,106 @@
+// Workers API クライアント
+const API_BASE_URL = process.env.NEXT_PUBLIC_WORKERS_API_URL || "http://localhost:8787";
+
+export interface CrawlRequest {
+  url: string;
+  maxPages?: number;
+}
+
+export interface CrawlResponse {
+  success: boolean;
+  data?: {
+    pages: Array<{
+      url: string;
+      title: string;
+      lastmod?: string;
+      changefreq?: string;
+      priority?: number;
+    }>;
+    totalPages: number;
+    crawledAt: string;
+  };
+  error?: string;
+}
+
+export interface SitemapGenerationRequest {
+  baseUrl: string;
+  pages: Array<{
+    url: string;
+    title: string;
+    lastmod?: string;
+    changefreq?: string;
+    priority?: number;
+  }>;
+  includeLastmod?: boolean;
+  includeChangefreq?: boolean;
+  includePriority?: boolean;
+}
+
+export interface SitemapGenerationResponse {
+  success: boolean;
+  data?: {
+    xml: string;
+    pageCount: number;
+    generatedAt: string;
+  };
+  error?: string;
+}
+
+class WorkersAPIClient {
+  private baseUrl: string;
+
+  constructor(baseUrl: string = API_BASE_URL) {
+    this.baseUrl = baseUrl;
+  }
+
+  async health(): Promise<{ status: string; timestamp: string }> {
+    const response = await fetch(`${this.baseUrl}/health`);
+    if (!response.ok) {
+      throw new Error(`Health check failed: ${response.status}`);
+    }
+    return response.json();
+  }
+
+  async crawl(request: CrawlRequest): Promise<CrawlResponse> {
+    const response = await fetch(`${this.baseUrl}/api/crawl`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Crawl request failed: ${response.status}`);
+    }
+
+    return response.json();
+  }
+
+  async generateSitemap(
+    request: SitemapGenerationRequest
+  ): Promise<SitemapGenerationResponse> {
+    const response = await fetch(`${this.baseUrl}/api/sitemap/generate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Sitemap generation failed: ${response.status}`);
+    }
+
+    return response.json();
+  }
+}
+
+// シングルトンインスタンス
+export const workersAPI = new WorkersAPIClient();
+
+// 個別のエクスポート関数
+export const healthCheck = () => workersAPI.health();
+export const crawlSitemap = (request: CrawlRequest) => workersAPI.crawl(request);
+export const generateSitemap = (request: SitemapGenerationRequest) =>
+  workersAPI.generateSitemap(request);

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,47 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // API Routes を Cloudflare Workers にリダイレクト
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination:
+          process.env.NODE_ENV === "production"
+            ? `https://sitemap-generator-api.${
+                process.env.CLOUDFLARE_WORKERS_DOMAIN || "workers.dev"
+              }/:path*`
+            : "http://localhost:8787/:path*",
+      },
+    ];
+  },
+
+  // 外部API呼び出しを許可
+  async headers() {
+    return [
+      {
+        source: "/api/:path*",
+        headers: [
+          {
+            key: "Access-Control-Allow-Origin",
+            value: "*",
+          },
+          {
+            key: "Access-Control-Allow-Methods",
+            value: "GET, POST, OPTIONS",
+          },
+          {
+            key: "Access-Control-Allow-Headers",
+            value: "Content-Type",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;
 
 // added by create cloudflare to enable calling `getCloudflareContext()` in `next dev`
-import { initOpenNextCloudflareForDev } from '@opennextjs/cloudflare';
+import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
 initOpenNextCloudflareForDev();

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:full": "concurrently \"pnpm workers:dev\" \"pnpm dev\"",
     "build": "pnpm run workers:build && next build",
     "start": "next start",
     "lint": "next lint",
@@ -14,6 +15,7 @@
     "cf:deploy": "pnpm run cf:build && wrangler pages deploy .open-next/worker",
     "cf:preview": "pnpm run cf:build && wrangler pages dev .open-next/worker",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts",
+    "deploy": "pnpm run workers:deploy && pnpm run cf:deploy",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",
@@ -37,6 +39,7 @@
     "@types/react-dom": "^19",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "concurrently": "^9.2.0",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
     "tailwind-merge": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
     "cf:deploy": "pnpm run cf:build && wrangler pages deploy .open-next/worker",
     "cf:preview": "pnpm run cf:build && wrangler pages dev .open-next/worker",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts",
-    "setup:deploy": "./scripts/setup-deploy.sh",
-    "setup:preview": "./scripts/setup-preview.sh",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      concurrently:
+        specifier: ^9.2.0
+        version: 9.2.0
       eslint:
         specifier: ^9
         version: 9.29.0(jiti@2.4.2)
@@ -1903,6 +1906,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -1930,6 +1937,11 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concurrently@9.2.0:
+    resolution: {integrity: sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   content-disposition@1.0.0:
     resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
@@ -2138,6 +2150,10 @@ packages:
     resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -2378,6 +2394,10 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -2772,6 +2792,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -3141,6 +3164,10 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3167,6 +3194,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
@@ -3236,6 +3266,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -3367,6 +3401,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -3401,6 +3439,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -3571,6 +3613,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
@@ -3579,6 +3625,14 @@ packages:
     resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -6172,6 +6226,12 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   clsx@2.1.1: {}
 
   color-convert@2.0.1:
@@ -6195,6 +6255,16 @@ snapshots:
   commander@2.20.3: {}
 
   concat-map@0.0.1: {}
+
+  concurrently@9.2.0:
+    dependencies:
+      chalk: 4.1.2
+      lodash: 4.17.21
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   content-disposition@1.0.0:
     dependencies:
@@ -6478,6 +6548,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.4
       '@esbuild/win32-ia32': 0.25.4
       '@esbuild/win32-x64': 0.25.4
+
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -6837,6 +6909,8 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -7214,6 +7288,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash@4.17.21: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -7572,6 +7648,8 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  require-directory@2.1.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -7603,6 +7681,10 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -7742,6 +7824,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.3: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -7893,6 +7977,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   tailwind-merge@3.3.1: {}
@@ -7927,6 +8015,8 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  tree-kill@1.2.2: {}
 
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
@@ -8150,9 +8240,23 @@ snapshots:
 
   ws@8.18.0: {}
 
+  y18n@5.0.8: {}
+
   yallist@5.0.0: {}
 
   yaml@2.8.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -4,8 +4,29 @@ import { generateSitemapXML, validateSitemapPages } from "./sitemap-generator";
 import { SitemapGenerationRequest, SitemapGenerationResponse } from "./sitemap-types";
 
 interface Env {
-  // 環境変数やバインディングをここに定義
-  // 例: MY_KV: KVNamespace;
+  ENVIRONMENT: string;
+  ALLOWED_ORIGINS?: string;
+  RATE_LIMIT_WINDOW_MS?: string;
+  RATE_LIMIT_MAX_REQUESTS?: string;
+  MAX_URLS_PER_SITEMAP?: string;
+  MAX_REQUEST_SIZE_MB?: string;
+}
+
+// CORS設定を動的に取得
+function getCorsHeaders(env: Env, request: Request): Record<string, string> {
+  const origin = request.headers.get("Origin");
+  const allowedOrigins = env.ALLOWED_ORIGINS?.split(",") || ["*"];
+
+  const corsHeaders: Record<string, string> = {
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  };
+
+  if (allowedOrigins.includes("*") || (origin && allowedOrigins.includes(origin))) {
+    corsHeaders["Access-Control-Allow-Origin"] = origin || "*";
+  }
+
+  return corsHeaders;
 }
 
 export default {
@@ -15,11 +36,7 @@ export default {
     const method = request.method;
 
     // CORS設定
-    const corsHeaders = {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type",
-    };
+    const corsHeaders = getCorsHeaders(env, request);
 
     // プリフライトリクエストの処理
     if (method === "OPTIONS") {
@@ -128,9 +145,3 @@ export default {
     }
   },
 };
-
-// 環境変数の型定義
-interface Env {
-  ENVIRONMENT: string;
-  NEXTJS_ENV?: string;
-}

--- a/workers/wrangler.toml
+++ b/workers/wrangler.toml
@@ -5,6 +5,11 @@ compatibility_flags = ["nodejs_compat"]
 
 [vars]
 ENVIRONMENT = "production"
+ALLOWED_ORIGINS = "https://sitemap-generator.pages.dev,https://your-custom-domain.com"
+RATE_LIMIT_WINDOW_MS = "60000"
+RATE_LIMIT_MAX_REQUESTS = "10"
+MAX_URLS_PER_SITEMAP = "500"
+MAX_REQUEST_SIZE_MB = "2"
 
 # D1データベース設定（後で追加）
 # [[d1_databases]]
@@ -13,6 +18,9 @@ ENVIRONMENT = "production"
 # database_id = "your-database-id"
 
 # ローカル開発設定
+[env.development]
+vars = { ENVIRONMENT = "development", ALLOWED_ORIGINS = "http://localhost:3000,http://localhost:3001" }
+
 [dev]
 port = 8787
 local_protocol = "http"


### PR DESCRIPTION
## Summary
Separate Next.js (frontend) and Cloudflare Workers (API) architecture for better deployment and development experience.

## Changes
- **Next.js**: Frontend only, API routes proxy to Workers
- **Cloudflare Workers**: All API processing
- **Development**: Concurrent development setup with `pnpm dev:full`
- **API Client**: Type-safe Workers API client
- **Deployment**: Independent deployment scripts

## Usage
```bash
# Development
pnpm dev:full

# Deploy
pnpm deploy
```

Fixes #3